### PR TITLE
Support Mac OS

### DIFF
--- a/gl.lua
+++ b/gl.lua
@@ -8882,6 +8882,9 @@ local gl, glu
 if ffi.os == "Windows" then
 	gl = ffi.load("opengl32")
 	glu = ffi.load("glu32")
+elseif ffi.os == "OSX" then
+	gl = ffi.load("/System/Library/Frameworks/OpenGL.framework/OpenGL")
+	glu = ffi.load("/System/Library/Frameworks/OpenGL.framework/OpenGL")
 else
 	gl = ffi.load("libGL.so.1")
 	glu = ffi.load("libGLU.so.1")


### PR DESCRIPTION
As explained [here](https://github.com/sonoro1234/LuaJIT-SDL2/issues/1), this was all that was needed for MacOS.
Does anima work on Mac OS?

Add "OSX" case to gl.lua to load the correct library. This works but I have not been able to find a single other example of that on Github, ie. dynamically loading GL libraries on Mac Os, regardless of the programming language used...
